### PR TITLE
Deduplicate operationIds for actions serving multiple routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixes
+
+- De-duplicate `operationId`s so the spec stays OpenAPI-valid when one action serves
+  multiple routes (e.g. `resources` PUT/PATCH update twins or dual-mounted controllers).
+  Colliding ids are disambiguated by verb, then by path; already-unique ids are unchanged
+  ([#2](https://github.com/DylanBlakemore/swagdox/issues/2)).
+
 ## [0.2.1] - 13 November 2025
 
 - Adds request body parameters to spec

--- a/lib/swagdox/spec.ex
+++ b/lib/swagdox/spec.ex
@@ -134,21 +134,57 @@ defmodule Swagdox.Spec do
   end
 
   defp render_paths(paths) do
+    operation_ids = assign_operation_ids(paths)
     grouped_paths = Enum.group_by(paths, & &1.path)
 
     Enum.reduce(grouped_paths, %{}, fn {path, paths}, acc ->
       acc_path =
         Enum.reduce(paths, %{}, fn path, acc_path ->
-          Map.put(acc_path, to_string(path.verb), render_path(path))
+          operation_id = Map.fetch!(operation_ids, {path.path, path.verb})
+          Map.put(acc_path, to_string(path.verb), render_path(path, operation_id))
         end)
 
       Map.put(acc, path, acc_path)
     end)
   end
 
-  defp render_path(path) do
+  # Builds a unique operationId for every path. The OpenAPI spec requires operationIds
+  # to be unique, but the base id (controller-function) collides whenever a single action
+  # serves more than one route (e.g. resources PUT/PATCH update twins, or a controller
+  # mounted under multiple scopes). Ids that are already unique are kept verbatim so we
+  # don't rename existing consumers' generated client functions.
+  defp assign_operation_ids(paths) do
+    paths
+    |> Enum.group_by(&Path.operation_id/1)
+    |> Enum.flat_map(fn
+      {base_id, [single]} -> [{{single.path, single.verb}, base_id}]
+      {base_id, group} -> disambiguate(base_id, group)
+    end)
+    |> Map.new()
+  end
+
+  # First disambiguate by verb (resolves PUT/PATCH twins). If that still collides
+  # (same verb at different paths), also append a path-derived slug.
+  defp disambiguate(base_id, group) do
+    with_verb = Enum.map(group, fn path -> {path, "#{base_id}-#{path.verb}"} end)
+    counts = Enum.frequencies(Enum.map(with_verb, fn {_path, id} -> id end))
+
+    Enum.map(with_verb, fn {path, id} ->
+      final = if counts[id] > 1, do: "#{id}-#{path_slug(path.path)}", else: id
+      {{path.path, path.verb}, final}
+    end)
+  end
+
+  defp path_slug(path) do
+    path
+    |> String.trim("/")
+    |> String.replace(["{", "}"], "")
+    |> String.replace("/", "-")
+  end
+
+  defp render_path(path, operation_id) do
     base = %{
-      "operationId" => Path.operation_id(path),
+      "operationId" => operation_id,
       "description" => path.description,
       "parameters" => render_parameters(path.parameters),
       "responses" => render_responses(path.responses),

--- a/test/swagdox/spec_test.exs
+++ b/test/swagdox/spec_test.exs
@@ -264,6 +264,78 @@ defmodule Swagdox.SpecTest do
              } = rendered["paths"]
     end
 
+    test "disambiguates PUT/PATCH update twins by verb" do
+      paths = [
+        %Path{
+          verb: "put",
+          path: "/things/{id}",
+          controller: MyApp.ThingController,
+          function: :update,
+          description: "Updates a Thing.",
+          request_body: []
+        },
+        %Path{
+          verb: "patch",
+          path: "/things/{id}",
+          controller: MyApp.ThingController,
+          function: :update,
+          description: "Updates a Thing.",
+          request_body: []
+        }
+      ]
+
+      rendered = Spec.render(%{spec() | paths: paths})["paths"]
+      thing = rendered["/things/{id}"]
+
+      assert thing["put"]["operationId"] == "MyApp.ThingController-update-put"
+      assert thing["patch"]["operationId"] == "MyApp.ThingController-update-patch"
+    end
+
+    test "disambiguates dual-mounted actions by verb and path" do
+      paths = [
+        %Path{
+          verb: "get",
+          path: "/benchmarks",
+          controller: MyApp.BenchmarkController,
+          function: :index,
+          description: "Lists benchmarks.",
+          request_body: []
+        },
+        %Path{
+          verb: "get",
+          path: "/web_api/querying/benchmarks",
+          controller: MyApp.BenchmarkController,
+          function: :index,
+          description: "Lists benchmarks.",
+          request_body: []
+        }
+      ]
+
+      rendered = Spec.render(%{spec() | paths: paths})["paths"]
+
+      first = rendered["/benchmarks"]["get"]["operationId"]
+      second = rendered["/web_api/querying/benchmarks"]["get"]["operationId"]
+
+      assert first == "MyApp.BenchmarkController-index-get-benchmarks"
+      assert second == "MyApp.BenchmarkController-index-get-web_api-querying-benchmarks"
+      assert first != second
+    end
+
+    test "keeps the bare operationId for a non-colliding action" do
+      path = %Path{
+        verb: "get",
+        path: "/things",
+        controller: MyApp.ThingController,
+        function: :index,
+        description: "Lists things.",
+        request_body: []
+      }
+
+      rendered = Spec.render(%{spec() | paths: [path]})["paths"]
+
+      assert rendered["/things"]["get"]["operationId"] == "MyApp.ThingController-index"
+    end
+
     test "renders the paths", %{spec: spec} do
       assert %{
                "/users" => %{


### PR DESCRIPTION
## Summary

- Make generated `operationId`s unique when one controller action serves more than one route
- Disambiguate by HTTP verb first, then by path; leave already-unique ids untouched
- Add `render/1` tests for the twin, dual-mount, and non-colliding cases

## Details

The OpenAPI spec requires `operationId`s to be unique across all operations, but Swagdox derived every id solely from `controller-function`. Any action that backs more than one route therefore produced duplicate ids. Two common Phoenix patterns hit this: `resources` registering both `PUT` and `PATCH` for `:update` at the same path, and a controller deliberately mounted under more than one scope. Downstream code generators (e.g. orval/MSW) turn operationIds into function names, so the collisions surface as hard TypeScript compile errors. See issue #2.

The uniqueness pass lives in `Swagdox.Spec.render_paths/1`, the only place with a view of all paths at once. Ids that are already unique keep the bare `controller-function` format, so existing consumers' generated client functions don't get renamed. When a base id is shared, we first append the verb (which resolves the PUT/PATCH twins into `…-update-put` / `…-update-patch`), and if that still collides — the same verb mounted at different paths — we additionally append a path-derived slug. Since the `{path, verb}` pair is unique per route, the result is guaranteed unique. Both routes stay documented rather than dropping one verb.

Closes #2