### PR TITLE
Add enum, nullable, format, and size/range constraints to the DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- Add constraint options to the `@param` and `@property` DSL: `enum`, `nullable`, `format`,
+  `min_length`/`max_length`, `minimum`/`maximum`, `pattern`, and `min_items`/`max_items`.
+  Scalar constraints apply to array items; `min_items`/`max_items` apply to the array. Nullable
+  rendering follows the configured `openapi_version` (`nullable: true` for 3.0, a `"null"` type
+  union for 3.1) ([#1](https://github.com/DylanBlakemore/swagdox/issues/1)).
+
 ## [0.2.1] - 13 November 2025
 
 - Adds request body parameters to spec

--- a/README.md
+++ b/README.md
@@ -113,6 +113,36 @@ Parameter specifications must follow the format:
 
 where `kwargs` is a keyword-list of additional arguments used by OpenAPI specs.
 
+#### Constraints
+
+Both `@param` and `@property` accept constraint options in their trailing keyword list. They
+are rendered onto the field's schema (keys are converted from snake_case to the OpenAPI
+camelCase form):
+
+| Option                     | Applies to        | OpenAPI key                |
+| -------------------------- | ----------------- | -------------------------- |
+| `enum: [...]`              | any scalar        | `enum`                     |
+| `format: "date-time"`      | strings           | `format`                   |
+| `nullable: true`           | any scalar        | see below                  |
+| `min_length` / `max_length`| strings           | `minLength` / `maxLength`  |
+| `minimum` / `maximum`      | numbers           | `minimum` / `maximum`      |
+| `pattern: "^..$"`          | strings           | `pattern`                  |
+| `min_items` / `max_items`  | arrays            | `minItems` / `maxItems`    |
+
+```elixir
+@property status, string, "Generation status", enum: ["generating", "complete", "failed"]
+@property created_at, string, "Creation timestamp", format: "date-time"
+@param tags(body), [string], "Tags", required: true, min_items: 1
+```
+
+For array types (e.g. `[string]`), scalar constraints (`enum`, `format`, `nullable`,
+`min_length`, `max_length`, `minimum`, `maximum`, `pattern`) apply to the array **items**, while
+`min_items` / `max_items` apply to the **array** itself.
+
+Nullability is rendered according to the configured `openapi_version`: `nullable: true` becomes
+`"nullable": true` under OpenAPI 3.0, and a `"null"` type union (e.g. `"type": ["string", "null"]`)
+under 3.1.
+
 #### Responses
 
 Response are described similarly, and must follow one of these formats:

--- a/lib/swagdox/parameter.ex
+++ b/lib/swagdox/parameter.ex
@@ -10,7 +10,8 @@ defmodule Swagdox.Parameter do
     :in,
     :required,
     :description,
-    :type
+    :type,
+    constraints: []
   ]
 
   @type t :: %__MODULE__{
@@ -18,7 +19,8 @@ defmodule Swagdox.Parameter do
           in: String.t(),
           required: boolean(),
           description: String.t(),
-          type: any()
+          type: any(),
+          constraints: keyword()
         }
 
   @doc """
@@ -55,7 +57,8 @@ defmodule Swagdox.Parameter do
       in: location,
       required: Keyword.get(opts, :required, false),
       description: description,
-      type: type
+      type: type,
+      constraints: Keyword.delete(opts, :required)
     }
   end
 
@@ -80,13 +83,14 @@ defmodule Swagdox.Parameter do
         }
   """
   @spec render(t()) :: map()
-  def render(parameter) do
+  @spec render(t(), String.t()) :: map()
+  def render(parameter, version \\ "3.0.0") do
     %{
       "name" => parameter.name,
       "in" => parameter.in,
       "required" => parameter.required,
       "description" => parameter.description,
-      "schema" => Type.render(parameter.type)
+      "schema" => Type.render(parameter.type, parameter.constraints, version)
     }
   end
 end

--- a/lib/swagdox/schema.ex
+++ b/lib/swagdox/schema.ex
@@ -7,7 +7,7 @@ defmodule Swagdox.Schema do
 
   defstruct [:module, :description, :example, :type, properties: %{}, required: []]
 
-  @type property :: {atom(), atom()}
+  @type property :: {atom(), atom(), keyword()}
   @type t :: %__MODULE__{
           type: String.t(),
           module: module(),
@@ -53,8 +53,9 @@ defmodule Swagdox.Schema do
   def properties(schema) do
     schema
     |> extract_properties()
-    |> Enum.map(fn {:property, [name, type, _description]} ->
-      {name, type}
+    |> Enum.map(fn
+      {:property, [name, type, _description]} -> {name, type, []}
+      {:property, [name, type, _description, constraints]} -> {name, type, constraints}
     end)
   end
 
@@ -88,14 +89,15 @@ defmodule Swagdox.Schema do
   end
 
   @spec render(t()) :: map()
-  def render(schema) do
+  @spec render(t(), String.t()) :: map()
+  def render(schema, version \\ "3.0.0") do
     name = name(schema)
 
     rendered =
       %{
         "description" => schema.description,
         "type" => schema.type,
-        "properties" => render_properties(schema.properties)
+        "properties" => render_properties(schema.properties, version)
       }
       |> render_example(schema)
 
@@ -108,9 +110,9 @@ defmodule Swagdox.Schema do
     Map.put(rendered, "example", example)
   end
 
-  defp render_properties(properties) do
-    Enum.into(properties, %{}, fn {key, value} ->
-      {to_string(key), Type.render(value)}
+  defp render_properties(properties, version) do
+    Enum.into(properties, %{}, fn {key, type, constraints} ->
+      {to_string(key), Type.render(type, constraints, version)}
     end)
   end
 end

--- a/lib/swagdox/spec.ex
+++ b/lib/swagdox/spec.ex
@@ -96,18 +96,18 @@ defmodule Swagdox.Spec do
       "openapi" => spec.openapi,
       "info" => render_info(spec.info),
       "servers" => render_servers(spec.servers),
-      "paths" => render_paths(spec.paths),
+      "paths" => render_paths(spec.paths, spec.openapi),
       "tags" => [],
       "components" => %{
-        "schemas" => render_schemas(spec.schemas),
+        "schemas" => render_schemas(spec.schemas, spec.openapi),
         "securitySchemes" => render_security_schemes(spec.security)
       }
     }
   end
 
-  defp render_schemas(schemas) do
+  defp render_schemas(schemas, version) do
     Enum.reduce(schemas, %{}, fn schema, acc ->
-      Map.merge(acc, Schema.render(schema))
+      Map.merge(acc, Schema.render(schema, version))
     end)
   end
 
@@ -133,24 +133,24 @@ defmodule Swagdox.Spec do
     end)
   end
 
-  defp render_paths(paths) do
+  defp render_paths(paths, version) do
     grouped_paths = Enum.group_by(paths, & &1.path)
 
     Enum.reduce(grouped_paths, %{}, fn {path, paths}, acc ->
       acc_path =
         Enum.reduce(paths, %{}, fn path, acc_path ->
-          Map.put(acc_path, to_string(path.verb), render_path(path))
+          Map.put(acc_path, to_string(path.verb), render_path(path, version))
         end)
 
       Map.put(acc, path, acc_path)
     end)
   end
 
-  defp render_path(path) do
+  defp render_path(path, version) do
     base = %{
       "operationId" => Path.operation_id(path),
       "description" => path.description,
-      "parameters" => render_parameters(path.parameters),
+      "parameters" => render_parameters(path.parameters, version),
       "responses" => render_responses(path.responses),
       "security" => render_security(path.security),
       "tags" => path.tags
@@ -159,30 +159,31 @@ defmodule Swagdox.Spec do
     case path.request_body do
       nil -> base
       [] -> base
-      body_params -> Map.put(base, "requestBody", render_request_body(body_params))
+      body_params -> Map.put(base, "requestBody", render_request_body(body_params, version))
     end
   end
 
-  defp render_parameters(parameters) do
-    Enum.map(parameters, &Parameter.render/1)
+  defp render_parameters(parameters, version) do
+    Enum.map(parameters, &Parameter.render(&1, version))
   end
 
-  defp render_request_body([single_param]) do
+  defp render_request_body([single_param], version) do
     %{
       "required" => single_param.required,
       "content" => %{
         "application/json" => %{
-          "schema" => Swagdox.Type.render(single_param.type)
+          "schema" => Swagdox.Type.render(single_param.type, single_param.constraints, version)
         }
       }
     }
   end
 
-  defp render_request_body(body_params) when is_list(body_params) and length(body_params) > 1 do
+  defp render_request_body(body_params, version)
+       when is_list(body_params) and length(body_params) > 1 do
     # Combine multiple body parameters into a single object schema with properties
     properties =
       Enum.reduce(body_params, %{}, fn param, acc ->
-        Map.put(acc, param.name, Swagdox.Type.render(param.type))
+        Map.put(acc, param.name, Swagdox.Type.render(param.type, param.constraints, version))
       end)
 
     required_fields =

--- a/lib/swagdox/type.ex
+++ b/lib/swagdox/type.ex
@@ -1,6 +1,13 @@
 defmodule Swagdox.Type do
   @moduledoc """
   Describes a type in an OpenAPI specification.
+
+  Types may carry constraints, expressed as a keyword list. Scalar constraints
+  (`enum`, `format`, `nullable`, `min_length`, `max_length`, `minimum`, `maximum`,
+  `pattern`) attach to the schema itself - or, for array types, to the array items.
+  `min_items` and `max_items` attach to the array. Nullability is rendered according
+  to the target OpenAPI version: `nullable: true` for 3.0.x, a `"null"` type union
+  for 3.1.x.
   """
 
   @primitive_types [
@@ -11,27 +18,52 @@ defmodule Swagdox.Type do
     "object"
   ]
 
+  @default_version "3.0.0"
+
+  # DSL keyword -> OpenAPI schema key. `nullable` is handled separately (it is
+  # version-dependent), and `required` is a parameter-level field, not a schema
+  # constraint, so it is stripped before rendering.
+  @constraint_keys %{
+    enum: "enum",
+    format: "format",
+    min_length: "minLength",
+    max_length: "maxLength",
+    minimum: "minimum",
+    maximum: "maximum",
+    pattern: "pattern",
+    min_items: "minItems",
+    max_items: "maxItems"
+  }
+
+  @array_keys [:min_items, :max_items]
+
   @type variable :: String.t() | [String.t()] | atom() | [atom()]
 
   @spec render(variable()) :: map()
-  def render(type) when type in @primitive_types do
-    %{"type" => type}
+  @spec render(variable(), keyword()) :: map()
+  @spec render(variable(), keyword(), String.t()) :: map()
+  def render(type, constraints \\ [], version \\ @default_version)
+
+  def render(type, constraints, version) when type in @primitive_types do
+    apply_constraints(%{"type" => type}, constraints, version)
   end
 
-  def render([type]) do
-    %{"type" => "array", "items" => render(type)}
+  def render([type], constraints, version) do
+    {array_level, item_level} = Keyword.split(constraints, @array_keys)
+    base = %{"type" => "array", "items" => render(type, item_level, version)}
+    apply_constraints(base, array_level, version)
   end
 
-  def render(type) when is_atom(type) do
+  def render(type, constraints, version) when is_atom(type) do
     type
     |> to_string()
     |> String.replace("Elixir.", "")
-    |> render()
+    |> render(constraints, version)
   end
 
-  def render(type) do
+  def render(type, constraints, version) do
     if String.match?(type, ~r/^[A-Z]/) do
-      reference(type)
+      apply_constraints(reference(type), constraints, version)
     else
       raise ArgumentError, "Unknown type: '#{type}'"
     end
@@ -40,5 +72,51 @@ defmodule Swagdox.Type do
   @spec reference(String.t() | atom()) :: map()
   def reference(type) do
     %{"$ref" => "#/components/schemas/#{type}"}
+  end
+
+  defp apply_constraints(base, constraints, version) do
+    {nullable, constraints} = Keyword.pop(constraints, :nullable, false)
+    constraints = Keyword.delete(constraints, :required)
+
+    base
+    |> merge_constraints(constraints)
+    |> apply_nullable(nullable, version)
+  end
+
+  defp merge_constraints(base, constraints) do
+    rendered =
+      Enum.into(constraints, %{}, fn {key, value} ->
+        case Map.fetch(@constraint_keys, key) do
+          {:ok, json_key} -> {json_key, value}
+          :error -> raise ArgumentError, "Unknown constraint: #{inspect(key)}"
+        end
+      end)
+
+    # OpenAPI 3.0 forbids siblings of `$ref`, so wrap in `allOf` when constraints
+    # must be attached to a reference. Primitive and array bases merge directly.
+    case base do
+      %{"$ref" => _} when rendered != %{} -> Map.merge(%{"allOf" => [base]}, rendered)
+      _ -> Map.merge(base, rendered)
+    end
+  end
+
+  defp apply_nullable(map, false, _version), do: map
+
+  defp apply_nullable(map, true, version) do
+    if String.starts_with?(version, "3.0") do
+      Map.put(map, "nullable", true)
+    else
+      nullable_union(map)
+    end
+  end
+
+  defp nullable_union(%{"type" => type} = map) when is_binary(type) do
+    Map.put(map, "type", [type, "null"])
+  end
+
+  defp nullable_union(map) do
+    # A `$ref`, `allOf`, or already-list type can't fold `"null"` into its type,
+    # so express the union explicitly.
+    %{"anyOf" => [map, %{"type" => "null"}]}
   end
 end

--- a/test/support/order.ex
+++ b/test/support/order.ex
@@ -5,8 +5,9 @@ defmodule Swagdox.Order do
   [Swagdox] Schema:
     @name OrderName
 
-    @property item, string, "Order item"
-    @property number, integer, "Order number"
+    @property item, string, "Order item", min_length: 1
+    @property number, integer, "Order number", minimum: 1
+    @property status, string, "Order status", enum: ["pending", "shipped", "delivered"]
 
     @example %{
       item: "item",

--- a/test/support/order_controller.ex
+++ b/test/support/order_controller.ex
@@ -35,7 +35,7 @@ defmodule SwagdoxWeb.OrderController do
 
   [Swagdox] API:
     @param order(body), OrderName, "Order attributes", required: true
-    @param organisation(header), string, "The organisation UUID", required: true
+    @param organisation(header), string, "The organisation UUID", required: true, format: "uuid"
 
     @response 201, OrderName, "Order created"
     @response 400, "Invalid order attributes"

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -6,9 +6,9 @@ defmodule Swagdox.User do
     @name User
 
     @property id, integer, "User id"
-    @property name, string, "User name"
-    @property email, string, "User email"
-    @property orders, [OrderName], "User orders"
+    @property name, string, "User name", nullable: true
+    @property email, string, "User email", format: "email"
+    @property orders, [OrderName], "User orders", max_items: 100
   """
   use Ecto.Schema
 

--- a/test/swagdox/parameter_test.exs
+++ b/test/swagdox/parameter_test.exs
@@ -31,6 +31,14 @@ defmodule Swagdox.ParameterTest do
                type: ["integer"]
              } = Parameter.build({"id", "body"}, ["integer"], "User IDs", required: true)
     end
+
+    test "stores constraint opts, separate from :required" do
+      param =
+        Parameter.build({"id", "body"}, ["integer"], "User IDs", required: true, min_items: 1)
+
+      assert param.required == true
+      assert param.constraints == [min_items: 1]
+    end
   end
 
   test "build/3" do
@@ -82,5 +90,19 @@ defmodule Swagdox.ParameterTest do
                }
              }
            } = Parameter.render(parameter)
+  end
+
+  test "render/2 emits constraints in the schema" do
+    parameter = %Swagdox.Parameter{
+      name: "status",
+      in: "query",
+      description: "Status",
+      required: false,
+      type: "string",
+      constraints: [enum: ["a", "b"]]
+    }
+
+    assert %{"schema" => %{"type" => "string", "enum" => ["a", "b"]}} =
+             Parameter.render(parameter, "3.0.0")
   end
 end

--- a/test/swagdox/parser_test.exs
+++ b/test/swagdox/parser_test.exs
@@ -252,6 +252,20 @@ defmodule Swagdox.ParserTest do
                {:property, ["user", ["User"], "User object"]}
     end
 
+    test "property with constraint options" do
+      line = "@property status, string, \"Status\", enum: [\"a\", \"b\"]"
+
+      assert Parser.parse_definition(line) ==
+               {:property, ["status", "string", "Status", [enum: ["a", "b"]]]}
+    end
+
+    test "param with a size constraint" do
+      line = "@param body(body), [User], \"Users\", required: true, min_items: 1"
+
+      assert Parser.parse_definition(line) ==
+               {:param, [{"body", "body"}, ["User"], "Users", [required: true, min_items: 1]]}
+    end
+
     test "list types" do
       line = "@response 200, [User], \"List of users\""
 

--- a/test/swagdox/parser_test.exs
+++ b/test/swagdox/parser_test.exs
@@ -186,9 +186,9 @@ defmodule Swagdox.ParserTest do
                  @name User
 
                  @property id, integer, "User id"
-                 @property name, string, "User name"
-                 @property email, string, "User email"
-                 @property orders, [OrderName], "User orders"
+                 @property name, string, "User name", nullable: true
+                 @property email, string, "User email", format: "email"
+                 @property orders, [OrderName], "User orders", max_items: 100
                """
     end
 

--- a/test/swagdox/schema_test.exs
+++ b/test/swagdox/schema_test.exs
@@ -6,7 +6,11 @@ defmodule Swagdox.SchemaTest do
   alias Swagdox.User
 
   test "properties/1" do
-    assert Schema.properties(Order) == [{"item", "string", []}, {"number", "integer", []}]
+    assert Schema.properties(Order) == [
+             {"item", "string", [min_length: 1]},
+             {"number", "integer", [minimum: 1]},
+             {"status", "string", [enum: ["pending", "shipped", "delivered"]]}
+           ]
   end
 
   test "description/1" do
@@ -21,7 +25,11 @@ defmodule Swagdox.SchemaTest do
     assert Schema.infer(Order) == %Schema{
              type: "object",
              module: Order,
-             properties: [{"item", "string", []}, {"number", "integer", []}],
+             properties: [
+               {"item", "string", [min_length: 1]},
+               {"number", "integer", [minimum: 1]},
+               {"status", "string", [enum: ["pending", "shipped", "delivered"]]}
+             ],
              description: "An order placed by a customer",
              example: %{item: "item", number: 1}
            }
@@ -102,11 +110,12 @@ defmodule Swagdox.SchemaTest do
              "User" => %{
                "description" => "A user of the application",
                "properties" => %{
-                 "email" => %{"type" => "string"},
+                 "email" => %{"type" => "string", "format" => "email"},
                  "id" => %{"type" => "integer"},
-                 "name" => %{"type" => "string"},
+                 "name" => %{"type" => "string", "nullable" => true},
                  "orders" => %{
                    "type" => "array",
+                   "maxItems" => 100,
                    "items" => %{"$ref" => "#/components/schemas/OrderName"}
                  }
                },

--- a/test/swagdox/schema_test.exs
+++ b/test/swagdox/schema_test.exs
@@ -6,7 +6,7 @@ defmodule Swagdox.SchemaTest do
   alias Swagdox.User
 
   test "properties/1" do
-    assert Schema.properties(Order) == [{"item", "string"}, {"number", "integer"}]
+    assert Schema.properties(Order) == [{"item", "string", []}, {"number", "integer", []}]
   end
 
   test "description/1" do
@@ -21,7 +21,7 @@ defmodule Swagdox.SchemaTest do
     assert Schema.infer(Order) == %Schema{
              type: "object",
              module: Order,
-             properties: [{"item", "string"}, {"number", "integer"}],
+             properties: [{"item", "string", []}, {"number", "integer", []}],
              description: "An order placed by a customer",
              example: %{item: "item", number: 1}
            }
@@ -46,7 +46,7 @@ defmodule Swagdox.SchemaTest do
     schema = %Schema{
       type: "object",
       module: Order,
-      properties: [{"item", "string"}, {"number", "integer"}]
+      properties: [{"item", "string", []}, {"number", "integer", []}]
     }
 
     assert Schema.render(schema) == %{
@@ -59,6 +59,40 @@ defmodule Swagdox.SchemaTest do
                }
              }
            }
+  end
+
+  test "render/2 with property constraints" do
+    schema = %Schema{
+      type: "object",
+      module: Order,
+      properties: [
+        {"status", "string", [enum: ["new", "done"]]},
+        {"created_at", "string", [format: "date-time"]}
+      ]
+    }
+
+    assert %{
+             "OrderName" => %{
+               "properties" => %{
+                 "status" => %{"type" => "string", "enum" => ["new", "done"]},
+                 "created_at" => %{"type" => "string", "format" => "date-time"}
+               }
+             }
+           } = Schema.render(schema)
+  end
+
+  test "render/2 renders nullable per the OpenAPI version" do
+    schema = %Schema{
+      type: "object",
+      module: Order,
+      properties: [{"title", "string", [nullable: true]}]
+    }
+
+    assert %{"OrderName" => %{"properties" => %{"title" => %{"nullable" => true}}}} =
+             Schema.render(schema, "3.0.0")
+
+    assert %{"OrderName" => %{"properties" => %{"title" => %{"type" => ["string", "null"]}}}} =
+             Schema.render(schema, "3.1.0")
   end
 
   test "render/1 with arrays" do

--- a/test/swagdox/spec_test.exs
+++ b/test/swagdox/spec_test.exs
@@ -118,7 +118,11 @@ defmodule Swagdox.SpecTest do
                  %Schema{
                    module: Swagdox.Order,
                    type: "object",
-                   properties: [{"item", "string", []}, {"number", "integer", []}],
+                   properties: [
+                     {"item", "string", [min_length: 1]},
+                     {"number", "integer", [minimum: 1]},
+                     {"status", "string", [enum: ["pending", "shipped", "delivered"]]}
+                   ],
                    required: []
                  },
                  %Schema{
@@ -126,9 +130,9 @@ defmodule Swagdox.SpecTest do
                    type: "object",
                    properties: [
                      {"id", "integer", []},
-                     {"name", "string", []},
-                     {"email", "string", []},
-                     {"orders", ["OrderName"], []}
+                     {"name", "string", [nullable: true]},
+                     {"email", "string", [format: "email"]},
+                     {"orders", ["OrderName"], [max_items: 100]}
                    ],
                    required: []
                  }

--- a/test/swagdox/spec_test.exs
+++ b/test/swagdox/spec_test.exs
@@ -118,17 +118,17 @@ defmodule Swagdox.SpecTest do
                  %Schema{
                    module: Swagdox.Order,
                    type: "object",
-                   properties: [{"item", "string"}, {"number", "integer"}],
+                   properties: [{"item", "string", []}, {"number", "integer", []}],
                    required: []
                  },
                  %Schema{
                    module: Swagdox.User,
                    type: "object",
                    properties: [
-                     {"id", "integer"},
-                     {"name", "string"},
-                     {"email", "string"},
-                     {"orders", ["OrderName"]}
+                     {"id", "integer", []},
+                     {"name", "string", []},
+                     {"email", "string", []},
+                     {"orders", ["OrderName"], []}
                    ],
                    required: []
                  }
@@ -262,6 +262,69 @@ defmodule Swagdox.SpecTest do
                  }
                }
              } = rendered["paths"]
+    end
+
+    test "threads constraints into a single body parameter schema" do
+      path = %Path{
+        verb: "post",
+        path: "/users",
+        description: "Creates Users.",
+        tags: ["users"],
+        request_body: [
+          Parameter.build({"users", "body"}, ["User"], "Users", required: true, min_items: 1)
+        ],
+        responses: []
+      }
+
+      rendered = Spec.render(%{spec() | paths: [path]})["paths"]
+
+      assert %{
+               "/users" => %{
+                 "post" => %{
+                   "requestBody" => %{
+                     "content" => %{
+                       "application/json" => %{
+                         "schema" => %{
+                           "type" => "array",
+                           "minItems" => 1,
+                           "items" => %{"$ref" => "#/components/schemas/User"}
+                         }
+                       }
+                     }
+                   }
+                 }
+               }
+             } = rendered
+    end
+
+    test "threads the OpenAPI version through to nullable rendering" do
+      path = %Path{
+        verb: "post",
+        path: "/users",
+        description: "Creates a User.",
+        tags: ["users"],
+        request_body: [
+          Parameter.build({"name", "body"}, "string", "Name", nullable: true)
+        ],
+        responses: []
+      }
+
+      spec_31 = %{spec() | paths: [path], openapi: "3.1.0"}
+      rendered = Spec.render(spec_31)["paths"]
+
+      assert %{
+               "/users" => %{
+                 "post" => %{
+                   "requestBody" => %{
+                     "content" => %{
+                       "application/json" => %{
+                         "schema" => %{"type" => ["string", "null"]}
+                       }
+                     }
+                   }
+                 }
+               }
+             } = rendered
     end
 
     test "renders the paths", %{spec: spec} do

--- a/test/swagdox/type_test.exs
+++ b/test/swagdox/type_test.exs
@@ -29,4 +29,97 @@ defmodule Swagdox.TypeTest do
       assert Type.render(MySchema) == %{"$ref" => "#/components/schemas/MySchema"}
     end
   end
+
+  describe "render/3 with constraints" do
+    test "enum on a primitive" do
+      assert Type.render("string", enum: ["a", "b"]) ==
+               %{"type" => "string", "enum" => ["a", "b"]}
+    end
+
+    test "format" do
+      assert Type.render("string", format: "date-time") ==
+               %{"type" => "string", "format" => "date-time"}
+    end
+
+    test "string length constraints" do
+      assert Type.render("string", min_length: 1, max_length: 10) ==
+               %{"type" => "string", "minLength" => 1, "maxLength" => 10}
+    end
+
+    test "numeric range constraints" do
+      assert Type.render("integer", minimum: 0, maximum: 100) ==
+               %{"type" => "integer", "minimum" => 0, "maximum" => 100}
+    end
+
+    test "pattern" do
+      assert Type.render("string", pattern: "^[a-z]+$") ==
+               %{"type" => "string", "pattern" => "^[a-z]+$"}
+    end
+
+    test "ignores :required (a parameter-level field, not a schema constraint)" do
+      assert Type.render("string", required: true) == %{"type" => "string"}
+    end
+
+    test "raises on an unknown constraint" do
+      assert_raise ArgumentError, "Unknown constraint: :wat", fn ->
+        Type.render("string", wat: true)
+      end
+    end
+
+    test "min_items/max_items attach to the array, scalar constraints to its items" do
+      assert Type.render(["string"], min_items: 1, max_items: 5, enum: ["a", "b"]) ==
+               %{
+                 "type" => "array",
+                 "minItems" => 1,
+                 "maxItems" => 5,
+                 "items" => %{"type" => "string", "enum" => ["a", "b"]}
+               }
+    end
+
+    test "constraints on an array of references attach to the items" do
+      assert Type.render(["User"], min_items: 1) ==
+               %{
+                 "type" => "array",
+                 "minItems" => 1,
+                 "items" => %{"$ref" => "#/components/schemas/User"}
+               }
+    end
+  end
+
+  describe "render/3 nullable" do
+    test "3.0.x emits nullable: true" do
+      assert Type.render("string", [nullable: true], "3.0.0") ==
+               %{"type" => "string", "nullable" => true}
+    end
+
+    test "3.1.x folds null into the type" do
+      assert Type.render("string", [nullable: true], "3.1.0") ==
+               %{"type" => ["string", "null"]}
+    end
+
+    test "3.1.x preserves sibling constraints when folding null" do
+      assert Type.render("string", [nullable: true, enum: ["a"]], "3.1.0") ==
+               %{"type" => ["string", "null"], "enum" => ["a"]}
+    end
+
+    test "nullable applies to array items, not the array" do
+      assert Type.render(["string"], [nullable: true], "3.0.0") ==
+               %{
+                 "type" => "array",
+                 "items" => %{"type" => "string", "nullable" => true}
+               }
+    end
+
+    test "3.1.x expresses a nullable reference as an anyOf union" do
+      assert Type.render("User", [nullable: true], "3.1.0") ==
+               %{"anyOf" => [%{"$ref" => "#/components/schemas/User"}, %{"type" => "null"}]}
+    end
+  end
+
+  describe "render/3 with references" do
+    test "wraps a reference in allOf when constraints are present (3.0-valid)" do
+      assert Type.render("User", format: "uuid") ==
+               %{"allOf" => [%{"$ref" => "#/components/schemas/User"}], "format" => "uuid"}
+    end
+  end
 end

--- a/test/swagdox_test.exs
+++ b/test/swagdox_test.exs
@@ -19,19 +19,27 @@ defmodule SwagdoxTest do
       "schemas" => %{
         "OrderName" => %{
           "description" => "An order placed by a customer",
-          "properties" => %{"item" => %{"type" => "string"}, "number" => %{"type" => "integer"}},
+          "properties" => %{
+            "item" => %{"type" => "string", "minLength" => 1},
+            "number" => %{"type" => "integer", "minimum" => 1},
+            "status" => %{
+              "type" => "string",
+              "enum" => ["pending", "shipped", "delivered"]
+            }
+          },
           "type" => "object",
           "example" => %{item: "item", number: 1}
         },
         "User" => %{
           "description" => "A user of the application",
           "properties" => %{
-            "email" => %{"type" => "string"},
+            "email" => %{"type" => "string", "format" => "email"},
             "id" => %{"type" => "integer"},
-            "name" => %{"type" => "string"},
+            "name" => %{"type" => "string", "nullable" => true},
             "orders" => %{
               "items" => %{"$ref" => "#/components/schemas/OrderName"},
-              "type" => "array"
+              "type" => "array",
+              "maxItems" => 100
             }
           },
           "type" => "object"
@@ -90,7 +98,7 @@ defmodule SwagdoxTest do
               "in" => "header",
               "name" => "organisation",
               "required" => true,
-              "schema" => %{"type" => "string"}
+              "schema" => %{"type" => "string", "format" => "uuid"}
             }
           ],
           "requestBody" => %{


### PR DESCRIPTION
## Summary

- Add constraint options to the `@param` and `@property` DSL: `enum`, `nullable`, `format`, `min_length`/`max_length`, `minimum`/`maximum`, `pattern`, and `min_items`/`max_items`
- Render nullability per the configured `openapi_version` (3.0 `nullable: true` vs 3.1 `"null"` type union)
- Document the new options in the README and changelog

## Details

The DSL could only express a field's primitive name (or `[Type]`, or a `$ref`), so any finite enum, nullable field, string format, or size/range rule degraded to a bare type and pushed consumers back into the source. The root cause was that `Swagdox.Type.render/1` received only the type and had nowhere to attach constraints, while the callers (`Schema.properties/1`, `Parameter`) discarded the trailing keyword opts the parser already produced.

This threads those opts through to rendering. `Type.render/3` now merges constraints onto the schema, converting snake_case DSL keys to the OpenAPI camelCase form. For array types, scalar constraints attach to the items while `min_items`/`max_items` attach to the array itself — so `[string]` with `min_items: 1` and `enum:` does the sensible thing. Nullability is the one version-sensitive case: the OpenAPI version already lives on the spec at render time, so it's threaded down and rendered as `nullable: true` for 3.0 or folded into the type for 3.1. Unknown constraint keys raise, matching the library's existing fail-loud behaviour on unknown types.

Closes #1